### PR TITLE
Variable names in sample appium.txt file for Android updated

### DIFF
--- a/bin/arc
+++ b/bin/arc
@@ -33,10 +33,10 @@ ARGV.each_index do |idx|
     end
     File.open toml, 'w' do |f|
       if b && b.match(/android/i)
-        f.puts %Q(APP_PATH="#{ENV['APP_PATH'] || '/path/to/my.apk'}")
-        f.puts %Q(APP_PACKAGE="#{ENV['APP_PACKAGE'] || 'com.my.Pkg'}")
-        f.puts %Q(APP_ACTIVITY="#{ENV['APP_ACTIVITY'] || 'StartActivity'}")
-        f.puts %Q(APP_WAIT_ACTIVITY="#{ENV['APP_WAIT_ACTIVITY'] || 'SplashActivity'}")
+        f.puts %Q([caps])
+        f.puts %Q(app = "#{ENV['APP_PATH'] || '/path/to/my.apk'}")
+        f.puts %Q(platformName = "com.my.Pkg")
+        f.puts %Q(deviceName = "Android")
       elsif b && b.match(/ios/i)
         # iOS requires only APP_PATH
         ios = ENV['APP_PATH']


### PR DESCRIPTION
arc setup android command creates sample appium.txt file but the variable names inside are different than it is referred at https://saucelabs.com/resources/appium-bootcamp/appium-bootcamp-2013-chapter-2-the-console

Looking at source code I see that we are trying to print to file what users have in their environment variables. I think it would be more helpful if we format it like this. They can just update appium.txt file and use it.
