### PR TITLE
Releasing appium session when exiting pry with exit or ctrl-d

### DIFF
--- a/lib/appium_console.rb
+++ b/lib/appium_console.rb
@@ -50,6 +50,11 @@ module Appium
 
           $stdout.puts "pry #{cmd.join(' ')}"
         end
+
+        Pry.hooks.add_hook(:after_session, "Release session hook") do |output, binding, pry|
+          output.puts "Closing appium session..."
+          $driver.x
+        end
         Pry::CLI.parse_options cmd
       end
     end


### PR DESCRIPTION
Fixes #53 with Pry hooks.