### PR TITLE
fixed arc setup ios|android command (issue #57)

### DIFF
--- a/appium_console.gemspec
+++ b/appium_console.gemspec
@@ -24,13 +24,13 @@ Gem::Specification.new do |s|
   s.require_paths = [ 'lib' ]
 
   # appium_lib version must match ruby console version.
-  s.add_runtime_dependency 'appium_lib', '>= 1.0.0'
-  s.add_runtime_dependency 'pry', '~> 0.10.1'
-  s.add_runtime_dependency 'bond', '~> 0.5.1'
-  s.add_runtime_dependency 'spec', '>= 5.3.4'
-  s.add_runtime_dependency 'thor', '>= 0.19'
-  s.add_development_dependency 'rake', '~> 10.4.2'
-  s.add_development_dependency 'appium_thor', '>= 1.0.1'
+  s.add_runtime_dependency 'appium_lib', '~> 8.0', '>= 8.0.3'
+  s.add_runtime_dependency 'pry', '~> 0.10'
+  s.add_runtime_dependency 'bond', '~> 0.5'
+  s.add_runtime_dependency 'spec', '~> 5.3', '>= 5.3.1'
+  s.add_runtime_dependency 'thor', '~> 0.19'
+  s.add_development_dependency 'rake', '~> 10.4'
+  s.add_development_dependency 'appium_thor', '~> 1.0', '>= 1.0.1'
   s.add_development_dependency 'posix-spawn', '~> 0.3.11'
 
   s.executables   = [ 'arc' ]

--- a/lib/appium_console/version.rb
+++ b/lib/appium_console/version.rb
@@ -2,6 +2,6 @@
 # Define Appium module so version can be required directly.
 module Appium; end unless defined? Appium
 module Appium::Console
-  VERSION = '2.0.2' unless defined? ::Appium::Console::VERSION
+  VERSION = '2.1.0' unless defined? ::Appium::Console::VERSION
   DATE = '2016-09-23' unless defined? ::Appium::Console::DATE
 end

--- a/lib/appium_console/version.rb
+++ b/lib/appium_console/version.rb
@@ -2,6 +2,6 @@
 # Define Appium module so version can be required directly.
 module Appium; end unless defined? Appium
 module Appium::Console
-  VERSION = '2.0.1' unless defined? ::Appium::Console::VERSION
-  DATE = '2016-03-18' unless defined? ::Appium::Console::DATE
+  VERSION = '2.0.2' unless defined? ::Appium::Console::VERSION
+  DATE = '2016-09-23' unless defined? ::Appium::Console::DATE
 end

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -9,7 +9,7 @@ module Appium::CLI
   module Config
     class << self
       def appium_txt_template_path
-        "templates/appium.txt.erb"
+        File.join(File.dirname(__FILE__), "..", "templates/appium.txt.erb")
       end
 
       def default_appium_txt_path
@@ -60,7 +60,8 @@ module Appium::CLI
     end
 
     desc "toml [FILE]", "Starts appium console session with path to toml file"
-    def toml appium_txt_path = Config.default_appium_txt_path
+    def toml
+      appium_txt_path = Config.default_appium_txt_path
       Appium::Console.setup appium_txt_path
       Appium::Console.start
     end


### PR DESCRIPTION
This addresses issue #57. The code was searching in the wrong place for the appium.txt template file bundled in this gem.
