### PR TITLE
Updated version of 'appium_lib' -> 9.3.5

### DIFF
--- a/appium_console.gemspec
+++ b/appium_console.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.require_paths = [ 'lib' ]
 
   # appium_lib version must match ruby console version.
-  s.add_runtime_dependency 'appium_lib', '~> 8.0', '>= 8.0.3'
+  s.add_runtime_dependency 'appium_lib', '~> 9.3.5'
   s.add_runtime_dependency 'pry', '~> 0.10'
   s.add_runtime_dependency 'bond', '~> 0.5'
   s.add_runtime_dependency 'spec', '~> 5.3', '>= 5.3.1'


### PR DESCRIPTION
I had come across issues when getting setup with arc regarding 'appium_lib'. 

Tested by updating gemspec to latest version manually and it did the trick. 