### PR TITLE
Fixed Main#toml to accept a file path parameter

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -62,8 +62,7 @@ module Appium::CLI
     end
 
     desc "toml [FILE]", "Starts appium console session with path to toml file"
-    def toml
-      appium_txt_path = Config.default_appium_txt_path
+    def toml(appium_txt_path = Config.default_appium_txt_path)
       Appium::Console.setup appium_txt_path
       Appium::Console.start
     end


### PR DESCRIPTION
The toml function must accept one parameter, so the user can point a
specific caps file.

The PR#59 removed the parameter from the Main#toml function, changing
a default parameter into a normal attribution.
I could not see a direct relation between this change and the fix proposed 
by de PR#59, so I think this will not break anything.

Is there a reason to don't have a Rakefile in this project? I would like to add
a test to avoid this problem in the future, because this is the only function 
that have a parameter and a Rakefile will help running the tests.