### PR TITLE
Allow minor and patch updates

### DIFF
--- a/appium_console.gemspec
+++ b/appium_console.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.require_paths = [ 'lib' ]
 
   # appium_lib version must match ruby console version.
-  s.add_runtime_dependency 'appium_lib', '~> 9.4.0'
+  s.add_runtime_dependency 'appium_lib', '~> 9'
   s.add_runtime_dependency 'pry', '~> 0.10'
   s.add_runtime_dependency 'bond', '~> 0.5'
   s.add_runtime_dependency 'spec', '~> 5.3', '>= 5.3.1'


### PR DESCRIPTION
Appium lib is now on `9.5.0`, loosening the gemspec restriction prevents `ruby_console` from restricting it too much when using bundler: 

https://github.com/appium/ruby_lib/compare/v9.4.10...v9.5.0
