### PR TITLE
require appium 9.6+

### DIFF
--- a/appium_console.gemspec
+++ b/appium_console.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.require_paths = [ 'lib' ]
 
   # appium_lib version must match ruby console version.
-  s.add_runtime_dependency 'appium_lib', '~> 9'
+  s.add_runtime_dependency 'appium_lib', '~> 9', '>= 9.6'
   s.add_runtime_dependency 'pry', '~> 0.10'
   s.add_runtime_dependency 'bond', '~> 0.5'
   s.add_runtime_dependency 'spec', '~> 5.3', '>= 5.3.1'

--- a/lib/start.rb
+++ b/lib/start.rb
@@ -13,7 +13,7 @@ if $driver.nil?
   # override command timeout so the server doesn't shut down after 60 seconds
   new_command_timeout = { caps: { newCommandTimeout: 999_999 }.merge(opts[:caps] || {}) }
   opts = opts.merge(new_command_timeout)
-  Appium::Driver.new(opts).start_driver
+  Appium::Driver.new(opts, true).start_driver
   Appium.promote_appium_methods Object
 end
 


### PR DESCRIPTION
confusing warning message "[DEPRECATION] Appium::Driver.new(opts) will not generate global driver by defaul" #76