### PR TITLE
require pry 0.11.x

### DIFF
--- a/appium_console.gemspec
+++ b/appium_console.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   # appium_lib version must match ruby console version.
   s.add_runtime_dependency 'appium_lib', '~> 9', '>= 9.6'
-  s.add_runtime_dependency 'pry', '~> 0.10'
+  s.add_runtime_dependency 'pry', '~> 0.11.0'
   s.add_runtime_dependency 'bond', '~> 0.5'
   s.add_runtime_dependency 'spec', '~> 5.3', '>= 5.3.1'
   s.add_runtime_dependency 'thor', '~> 0.19'

--- a/lib/appium_console.rb
+++ b/lib/appium_console.rb
@@ -55,7 +55,9 @@ module Appium
           output.puts "Closing appium session..."
           $driver.x
         end
-        Pry::CLI.parse_options cmd
+
+        opts = Pry::CLI.parse_options cmd
+        Pry::CLI.start(opts)
       end
     end
   end


### PR DESCRIPTION
according to https://github.com/pry/pry/blob/master/CHANGELOG.md, `Pry` command doesn't start until calling `Pry::CLI.start` from `pry 0.11.0`.

> Pry::CLI.parse_options does not start Pry anymore (#1393)

In this PR, the lib starts requiring `pry 0.11.0` and fix the change.

---

arc will exit after a connection is established #80