### PR TITLE
Added double quotes in appium.txt template

### DIFF
--- a/templates/appium.txt.erb
+++ b/templates/appium.txt.erb
@@ -6,10 +6,10 @@ platformVersion = <%= caps[:platform_version] %>
 deviceName = "<%= caps[:device_name] %>"
 app = "<%= caps[:path_to_app] %>"
 <% if !caps[:app_package].nil? -%>
-appPackage = <%= caps[:app_package] %>
+appPackage = "<%= caps[:app_package] %>"
 <% end -%>
 <% if !caps[:app_activity].nil? -%>
-appActivity = <%= caps[:app_activity] %>
+appActivity = "<%= caps[:app_activity] %>"
 <% end -%>
 
 [appium_lib]


### PR DESCRIPTION
The appium.txt template is missing quotes for the appPackage and
appActivity caps.
So, new users, when filling their first appium.txt tend to don't use 
quotes for these two caps, what results in the following error:

![without quotes](https://user-images.githubusercontent.com/1906192/33633915-93169e3c-d9f9-11e7-8606-8af087cdeaae.png)

