### PR TITLE
Added double quotes in the appium.txt template

### DIFF
--- a/templates/appium.txt.erb
+++ b/templates/appium.txt.erb
@@ -1,7 +1,7 @@
 [caps]
 platformName = "<%= caps[:platform_name] %>"
 <% if !caps[:platform_version].nil? -%>
-platformVersion = <%= caps[:platform_version] %>
+platformVersion = "<%= caps[:platform_version] %>"
 <% end -%>
 deviceName = "<%= caps[:device_name] %>"
 app = "<%= caps[:path_to_app] %>"


### PR DESCRIPTION
I found one more line in the appium.txt template that does not have 
double quotes: **platformVersion**

For a version like 10.3 it is not a problem, but for version 11.0.3 
we got an parser error.

No double quotes in the template can lead new user to this error.

![screen shot 2017-12-15 at 3 59 26 pm](https://user-images.githubusercontent.com/1906192/34054382-cbfdb054-e1b1-11e7-9cdf-7d04ba8ac151.png)
