### PR TITLE
add require awesome_print

### DIFF
--- a/lib/appium_console.rb
+++ b/lib/appium_console.rb
@@ -2,6 +2,7 @@
 require 'rubygems'
 require 'pry'
 require 'appium_lib'
+require 'awesome_print'
 
 # Silence gem warnings
 Gem::Specification.class_eval do


### PR DESCRIPTION
When I add dependency of "awesome_print", then I forget to require it into the file.
https://github.com/appium/ruby_console/pull/88