### PR TITLE
Add rubocop remove awesomeprint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,14 @@
+AllCops:
+  TargetRubyVersion: 2.2
+Metrics/LineLength:
+  Max: 128
+Metrics/MethodLength:
+  Enabled: false
+Metrics/AbcSize:
+  Enabled: false
+Style/Documentation:
+  Enabled: false
+Style/GlobalVars:
+  Enabled: false
+Layout/IndentHeredoc:
+  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,10 @@
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+require 'rubocop/rake_task'
+
+desc('Execute RuboCop static code analysis')
+RuboCop::RakeTask.new(:rubocop) do |t|
+  t.patterns = %w(lib test)
+  t.options = %w(-D)
+  t.fail_on_error = true
+end

--- a/appium_console.gemspec
+++ b/appium_console.gemspec
@@ -26,13 +26,14 @@ Gem::Specification.new do |s|
   # appium_lib version must match ruby console version.
   s.add_runtime_dependency 'appium_lib', '~> 9.16'
   s.add_runtime_dependency 'awesome_print', '~> 1.7'
-  s.add_runtime_dependency 'pry', '~> 0.12.0'
+  s.add_runtime_dependency 'pry', '~> 0.11.0'
   s.add_runtime_dependency 'bond', '~> 0.5'
   s.add_runtime_dependency 'spec', '~> 5.3', '>= 5.3.1'
   s.add_runtime_dependency 'thor', '~> 0.19'
   s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'appium_thor', '~> 1.0', '>= 1.0.1'
   s.add_development_dependency 'posix-spawn', '~> 0.3.11'
+  s.add_development_dependency 'rubocop', '0.61.0'
 
   s.executables   = [ 'arc' ]
   s.files = `git ls-files`.split "\n"

--- a/appium_console.gemspec
+++ b/appium_console.gemspec
@@ -25,8 +25,7 @@ Gem::Specification.new do |s|
 
   # appium_lib version must match ruby console version.
   s.add_runtime_dependency 'appium_lib', '~> 9.16'
-  s.add_runtime_dependency 'awesome_print', '~> 1.7'
-  s.add_runtime_dependency 'pry', '~> 0.11.0'
+  s.add_runtime_dependency 'pry', '~> 0.12.0'
   s.add_runtime_dependency 'bond', '~> 0.5'
   s.add_runtime_dependency 'spec', '~> 5.3', '>= 5.3.1'
   s.add_runtime_dependency 'thor', '~> 0.19'

--- a/lib/appium_console.rb
+++ b/lib/appium_console.rb
@@ -1,7 +1,6 @@
 require 'rubygems'
 require 'pry'
 require 'appium_lib'
-require 'awesome_print'
 
 # Silence gem warnings
 Gem::Specification.class_eval do

--- a/lib/appium_console.rb
+++ b/lib/appium_console.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'rubygems'
 require 'pry'
 require 'appium_lib'
@@ -6,14 +5,13 @@ require 'awesome_print'
 
 # Silence gem warnings
 Gem::Specification.class_eval do
-  def self.warn args
-  end
+  def self.warn(args); end
 end
 
 module Appium
   module Console
     class << self
-      def setup appium_txt_path
+      def setup(appium_txt_path)
         Pry.send(:define_singleton_method, :pry_load_appium_txt) do |opts = {}|
           verbose = opts.fetch :verbose, false
           path = appium_txt_path
@@ -23,19 +21,20 @@ module Appium
         Pry.send(:define_singleton_method, :reload) do
           parsed = Pry.pry_load_appium_txt
           return unless parsed && parsed[:appium_lib] && parsed[:appium_lib][:require]
+
           requires = parsed[:appium_lib][:require]
           requires.each do |file|
             # If a page obj is deleted then load will error.
             begin
               load file
-            rescue # LoadError: cannot load such file
+            rescue LoadError => e
+              puts e.message
             end
           end
         end
       end
 
       def start
-        AwesomePrint.pry!
         start = File.expand_path 'start.rb', __dir__
         cmd = ['-r', start]
 
@@ -45,14 +44,14 @@ module Appium
           requires = parsed[:appium_lib][:require]
 
           unless requires.empty?
-            load_files = requires.map {|f| %(require "#{f}";)}.join "\n"
+            load_files = requires.map { |f| %(require "#{f}";) }.join "\n"
             cmd += ['-e', load_files]
           end
 
           $stdout.puts "pry #{cmd.join(' ')}"
         end
 
-        Pry.hooks.add_hook(:after_session, 'Release session hook') do |output, binding, pry|
+        Pry.hooks.add_hook(:after_session, 'Release session hook') do |output, _binding, _pry|
           output.puts 'Closing appium session...'
           $driver.x
         end

--- a/lib/appium_console/version.rb
+++ b/lib/appium_console/version.rb
@@ -1,7 +1,8 @@
-# encoding: utf-8
 # Define Appium module so version can be required directly.
 module Appium; end unless defined? Appium
-module Appium::Console
-  VERSION = '2.10.0' unless defined? ::Appium::Console::VERSION
-  DATE = '2018-12-19' unless defined? ::Appium::Console::DATE
+module Appium
+  module Console
+    VERSION = '2.10.0'.freeze unless defined? ::Appium::Console::VERSION
+    DATE = '2018-12-19'.freeze unless defined? ::Appium::Console::DATE
+  end
 end

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -5,7 +5,7 @@ require 'appium_lib/version'
 require 'erb'
 require 'appium_console'
 
-module Appium::CLI
+module Appium::CLI # rubocop:disable Style/ClassAndModuleChildren
   module Config
     class << self
       def default_appium_txt_path
@@ -13,20 +13,20 @@ module Appium::CLI
       end
 
       def template(caps)
-        <<-EOS.gsub(/skip\s/, '')
+        <<-TEMPLATE.gsub(/skip\s/, '')
 [caps]
 platformName = "#{caps[:platform_name]}"
-#{ caps[:platform_version] ? "platformVersion = \"#{caps[:platform_version]}\"" : 'skip' }
-#{ caps[:device_name] ? "deviceName = \"#{caps[:device_name]}\"" : 'skip' }
+#{caps[:platform_version] ? "platformVersion = \"#{caps[:platform_version]}\"" : 'skip'}
+#{caps[:device_name] ? "deviceName = \"#{caps[:device_name]}\"" : 'skip'}
 app = "#{caps[:path_to_app]}"
-#{ caps[:app_package] ? "appPackage = \"#{caps[:app_package]}\"" : 'skip' }
-#{ caps[:app_activity] ? "appActivity = \"#{caps[:app_activity]}\"" : 'skip' }
+#{caps[:app_package] ? "appPackage = \"#{caps[:app_package]}\"" : 'skip'}
+#{caps[:app_activity] ? "appActivity = \"#{caps[:app_activity]}\"" : 'skip'}
 
 [appium_lib]
 server_url = "http://127.0.0.1:4723/wd/hub"
 sauce_username = ""
 sauce_access_key = ""
-        EOS
+        TEMPLATE
       end
     end
   end

--- a/lib/start.rb
+++ b/lib/start.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'rubygems'
 require 'appium_lib'
 
@@ -24,7 +23,8 @@ begin
   # set current_spec. fixes:
   # NoMethodError: undefined method `assert_equal' for nil:NilClass
   Minitest::Spec.new 'pry'
-rescue
+rescue StandardError => e
+  puts(e.message)
 end
 
 def reload

--- a/test/simple.rb
+++ b/test/simple.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-#
 # run with
 # ruby my_test.rb
 #


### PR DESCRIPTION
- add rubocop
- remove awesome_print
    - This library faces some errors like below because of awesome_print
    ```
    IOError: closed stream
    from /Users/user/.rvm/gems/ruby-2.1.0-preview1/gems/awesome_print-1.2.0/lib/awesome_print/formatter.rb:199:in `directory?'
    ```
     - The fix has PRed for a couple of years, but it has not been merged yet. The PR is not so active. (It also looks no alternative)

Thus, I would remove the print to reduce errors out of appium related command