### PR TITLE
feat: remove the global driver hack

### DIFF
--- a/appium_console.gemspec
+++ b/appium_console.gemspec
@@ -10,7 +10,7 @@ add_to_path 'lib'
 require 'appium_console/version'
 
 Gem::Specification.new do |s|
-  s.required_ruby_version = '>= 2.6'
+  s.required_ruby_version = '>= 2.7'
 
   s.name          = 'appium_console'
   s.version       = Appium::Console::VERSION
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.require_paths = [ 'lib' ]
 
   # appium_lib version must match ruby console version.
-  s.add_runtime_dependency 'appium_lib', '12.0.1'
+  s.add_runtime_dependency 'appium_lib', '~> 12.1.1'
   s.add_runtime_dependency 'pry', '~> 0.14.0'
   s.add_runtime_dependency 'spec', '~> 5.3', '>= 5.3.1'
   s.add_runtime_dependency 'thor', '>= 0.19', '< 2.0'

--- a/appium_console.gemspec
+++ b/appium_console.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.require_paths = [ 'lib' ]
 
   # appium_lib version must match ruby console version.
-  s.add_runtime_dependency 'appium_lib', '~> 12.1.1'
+  s.add_runtime_dependency 'appium_lib', '~> 12.1.2'
   s.add_runtime_dependency 'pry', '~> 0.14.0'
   s.add_runtime_dependency 'spec', '~> 5.3', '>= 5.3.1'
   s.add_runtime_dependency 'thor', '>= 0.19', '< 2.0'

--- a/lib/appium_console.rb
+++ b/lib/appium_console.rb
@@ -52,7 +52,7 @@ module Appium
 
         Pry.hooks.add_hook(:after_session, 'Release session hook') do |output, _binding, _pry|
           output.puts 'Closing appium session...'
-          $driver.x
+          x
         end
 
         opts = Pry::CLI.parse_options cmd

--- a/lib/start.rb
+++ b/lib/start.rb
@@ -9,14 +9,14 @@ require 'appium_lib'
 # old Pry may not respond to config
 Pry.respond_to?(:config) ? Pry.config.command_prefix = '%' : ''
 
-if $driver.nil?
-  opts = Pry.pry_load_appium_txt
-  # override command timeout so the server doesn't shut down after 60 seconds
-  new_command_timeout = { caps: { newCommandTimeout: 999_999 }.merge(opts[:caps] || {}) }
-  opts = opts.merge(new_command_timeout)
-  Appium::Driver.new(opts, true).start_driver
-  Appium.promote_appium_methods Object
-end
+opts = Pry.pry_load_appium_txt
+# override command timeout so the server doesn't shut down after 60 seconds
+new_command_timeout = { caps: { newCommandTimeout: 999_999 }.merge(opts[:caps] || {}) }
+opts = opts.merge(new_command_timeout)
+core = Appium::Driver.new opts, false
+core.start_driver
+Appium.promote_appium_methods Object, core
+
 
 # Load minitest
 begin


### PR DESCRIPTION
This pr removes `$driver`, while the usage has no change as the base usage